### PR TITLE
Add check for execution by root.

### DIFF
--- a/usb_speed
+++ b/usb_speed
@@ -188,6 +188,12 @@ do_set_usb_speed() {
 # -- start of script
 # --
 
+if [ "$(id -u)" != "0" ]; then
+	err_msg "\n** This script must be run as root. **\n"
+	do_display_help "$cmd"
+	exit 1
+fi
+
 # Parse command line parameters
 while :
 do


### PR DESCRIPTION
Get debugfs file not found message as it is only accessible as root.   Add check for execution by root, and issue sensible error message if not.
